### PR TITLE
Restore some C89 compliance (variable declarations in for loops)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ geom-ctl-io.c
 geomtst
 nlopt-constants.scm
 utils/test-prism
+*.dat

--- a/utils/geom.c
+++ b/utils/geom.c
@@ -2314,12 +2314,12 @@ double min_distance_to_quadrilateral(vector3 p, vector3 o, vector3 v1, vector3 v
 
 // fc==0/1 for floor/ceiling
 double min_distance_to_prism_roof_or_ceiling(vector3 pp, prism *prsm, int fc) {
-  int num_vertices = prsm->vertices_p.num_items;
+  int num_vertices = prsm->vertices_p.num_items, i;
   vector3 op = {0.0, 0.0, 0.0}; // origin of floor/ceiling
   vector3 vps[num_vertices];
   if (fc == 1) {
     memcpy(vps, prsm->vertices_top_p.items, num_vertices * sizeof(vector3));
-    for (int i = 0; i < num_vertices; i++) {
+    for (i = 0; i < num_vertices; i++) {
       vps[i].z = 0;
     }
     op.z = prsm->height;
@@ -2450,7 +2450,7 @@ double get_prism_volume(prism *prsm) {
     return get_area_of_polygon_from_nodes(prsm->vertices_p.items, prsm->vertices_p.num_items) * fabs(prsm->height);
   }
   else {
-    int num_vertices = prsm->vertices_p.num_items;
+    int num_vertices = prsm->vertices_p.num_items, nv;
     double bottom_polygon_area = get_area_of_polygon_from_nodes(prsm->vertices_p.items, prsm->vertices_p.num_items);
     double top_polygon_area = get_area_of_polygon_from_nodes(prsm->vertices_top_p.items, prsm->vertices_top_p.num_items);
     double volume;
@@ -2467,7 +2467,7 @@ double get_prism_volume(prism *prsm) {
       volume = fabs(top_polygon_area * prsm->height);
       memcpy(wedges_a, prsm->vertices_top_p.items, num_vertices * sizeof(vector3));
       memcpy(wedges_b, prsm->vertices_top_p.items, num_vertices * sizeof(vector3));
-      for (int nv = 0; nv < num_vertices; nv++) {
+      for (nv = 0; nv < num_vertices; nv++) {
         wedges_b[nv].z = 0.0;
       }
       memcpy(wedges_c, prsm->vertices_p.items, num_vertices * sizeof(vector3));
@@ -2476,12 +2476,12 @@ double get_prism_volume(prism *prsm) {
       volume = fabs(bottom_polygon_area * prsm->height);
       memcpy(wedges_a, prsm->vertices_p.items, num_vertices * sizeof(vector3));
       memcpy(wedges_b, prsm->vertices_p.items, num_vertices * sizeof(vector3));
-      for (int nv = 0; nv < num_vertices; nv++) {
+      for (nv = 0; nv < num_vertices; nv++) {
         wedges_b[nv].z = prsm->height;
       }
       memcpy(wedges_c, prsm->vertices_top_p.items, num_vertices * sizeof(vector3));
     }
-    for (int nv = 0; nv < num_vertices; nv++) {
+    for (nv = 0; nv < num_vertices; nv++) {
       int nvp1 = (nv + 1 == num_vertices ? 0 : nv + 1);
       volume += get_volume_irregular_triangular_prism(wedges_a[nv], wedges_b[nv], wedges_c[nv], wedges_a[nvp1], wedges_b[nvp1], wedges_c[nvp1]);
     }

--- a/utils/test-prism.c
+++ b/utils/test-prism.c
@@ -546,6 +546,7 @@ double relative_error(double actual, double expected) {
 }
 
 int test_helper_functions_on_octagonal_c_prism() {
+  int i;
   double tolerance = 5.0e-5;
 
   void *m = NULL;
@@ -660,12 +661,12 @@ int test_helper_functions_on_octagonal_c_prism() {
   point_in_prism_expected_normal_sidewall[24] = 0; // center of the c
 
   int point_in_prism_actual_normal_sidewall[point_in_prism_test_points_normal_sidewall.num_items];
-  for (int i = 0; i < point_in_prism_test_points_normal_sidewall.num_items; i++) {
+  for (i = 0; i < point_in_prism_test_points_normal_sidewall.num_items; i++) {
     num_tests_normal++;
     point_in_prism_actual_normal_sidewall[i] = point_in_fixed_pobjectp(point_in_prism_test_points_normal_sidewall.items[i], &octagon_c_normal_sidewall_geom_object);
   }
 
-  for (int i = 0; i < point_in_prism_test_points_normal_sidewall.num_items; i++) {
+  for (i = 0; i < point_in_prism_test_points_normal_sidewall.num_items; i++) {
     if (point_in_prism_actual_normal_sidewall[i] != point_in_prism_expected_normal_sidewall[i]) {
       ctl_printf("\tAt (%f, %f, %f) we expected point_in_fixed_pobjectp on the normal sidewall prism to return %i, but instead it returned %i\n", point_in_prism_test_points_normal_sidewall.items[i].x, point_in_prism_test_points_normal_sidewall.items[i].y, point_in_prism_test_points_normal_sidewall.items[i].z, point_in_prism_expected_normal_sidewall[i], point_in_prism_actual_normal_sidewall[i]);
       num_failed_normal++;
@@ -729,12 +730,12 @@ int test_helper_functions_on_octagonal_c_prism() {
   point_in_prism_expected_tapered_sidewall[24] = 0; // center of the c
 
   int point_in_prism_actual_tapered_sidewall[point_in_prism_test_points_tapered_sidewall.num_items];
-  for (int i = 0; i < point_in_prism_test_points_tapered_sidewall.num_items; i++) {
+  for (i = 0; i < point_in_prism_test_points_tapered_sidewall.num_items; i++) {
     num_tests_tapered++;
     point_in_prism_actual_tapered_sidewall[i] = point_in_fixed_pobjectp(point_in_prism_test_points_tapered_sidewall.items[i], &octagon_c_two_half_degree_sidewall_geom_object);
   }
 
-  for (int i = 0; i < point_in_prism_test_points_tapered_sidewall.num_items; i++) {
+  for (i = 0; i < point_in_prism_test_points_tapered_sidewall.num_items; i++) {
     if (point_in_prism_actual_tapered_sidewall[i] != point_in_prism_expected_tapered_sidewall[i]) {
       ctl_printf("\tAt (%f, %f, %f) we expected point_in_fixed_pobjectp on the tapered sidewall prism to return %i, but instead it returned %i\n", point_in_prism_test_points_tapered_sidewall.items[i].x, point_in_prism_test_points_tapered_sidewall.items[i].y, point_in_prism_test_points_tapered_sidewall.items[i].z, point_in_prism_expected_tapered_sidewall[i], point_in_prism_actual_tapered_sidewall[i]);
       num_failed_tapered++;
@@ -809,12 +810,12 @@ int test_helper_functions_on_octagonal_c_prism() {
   normal_to_prism_expected_normal_sidewall[29] = make_vector3(0.0000000, 0.0000000, 1.0000000);
 
   vector3 normal_to_prism_actual_normal_sidewall[normal_to_prism_test_points_normal_sidewall.num_items];
-  for (int i = 0; i < normal_to_prism_test_points_normal_sidewall.num_items; i++) {
+  for (i = 0; i < normal_to_prism_test_points_normal_sidewall.num_items; i++) {
     num_tests_normal++;
     normal_to_prism_actual_normal_sidewall[i] = unit_vector3(normal_to_object(normal_to_prism_test_points_normal_sidewall.items[i], octagon_c_normal_sidewall_geom_object));
   }
 
-  for (int i = 0; i < normal_to_prism_test_points_normal_sidewall.num_items; i++) {
+  for (i = 0; i < normal_to_prism_test_points_normal_sidewall.num_items; i++) {
     if (!vector3_nearly_equal(normal_to_prism_expected_normal_sidewall[i], normal_to_prism_actual_normal_sidewall[i], tolerance)
         && !vector3_nearly_equal(normal_to_prism_expected_normal_sidewall[i], vector3_scale(-1, normal_to_prism_actual_normal_sidewall[i]), tolerance)) {
       num_failed_normal++;
@@ -892,12 +893,12 @@ int test_helper_functions_on_octagonal_c_prism() {
   normal_to_prism_expected_tapered_sidewall[29] = make_vector3(0.0000000, 0.0000000, 1.0000000);
 
   vector3 normal_to_prism_actual_tapered_sidewall[normal_to_prism_test_points_tapered_sidewall.num_items];
-  for (int i = 0; i < normal_to_prism_test_points_tapered_sidewall.num_items; i++) {
+  for (i = 0; i < normal_to_prism_test_points_tapered_sidewall.num_items; i++) {
     num_tests_tapered++;
     normal_to_prism_actual_tapered_sidewall[i] = unit_vector3(normal_to_object(normal_to_prism_test_points_tapered_sidewall.items[i], octagon_c_two_half_degree_sidewall_geom_object));
   }
 
-  for (int i = 0; i < normal_to_prism_test_points_tapered_sidewall.num_items; i++) {
+  for (i = 0; i < normal_to_prism_test_points_tapered_sidewall.num_items; i++) {
     if (!vector3_nearly_equal(normal_to_prism_expected_tapered_sidewall[i], normal_to_prism_actual_tapered_sidewall[i], tolerance)
         && !vector3_nearly_equal(normal_to_prism_expected_tapered_sidewall[i], vector3_scale(-1, normal_to_prism_actual_tapered_sidewall[i]), tolerance)) {
       num_failed_tapered++;
@@ -967,7 +968,7 @@ int test_helper_functions_on_octagonal_c_prism() {
   intersect_line_with_prism_b_normal_sidewall[8] = 300; // between top point 3 and center of c on bottom
 
   double intersect_line_with_prism_actual_normal_sidewall[intersect_line_with_prism_test_points_normal_sidewall.num_items];
-  for (int i = 0; i < intersect_line_with_prism_test_points_normal_sidewall.num_items; i++) {
+  for (i = 0; i < intersect_line_with_prism_test_points_normal_sidewall.num_items; i++) {
     num_tests_normal++;
     vector3 p = intersect_line_with_prism_test_points_normal_sidewall.items[i];
     vector3 d = intersect_line_with_prism_test_vectors_normal_sidewall[i];
@@ -977,7 +978,7 @@ int test_helper_functions_on_octagonal_c_prism() {
     intersect_line_with_prism_actual_normal_sidewall[i] = intersect_line_segment_with_object(p, d, o, a, b);
   }
 
-  for (int i = 0; i < intersect_line_with_prism_test_points_normal_sidewall.num_items; i++) {
+  for (i = 0; i < intersect_line_with_prism_test_points_normal_sidewall.num_items; i++) {
     double actual = intersect_line_with_prism_actual_normal_sidewall[i];
     double expected = intersect_line_with_prism_expected_normal_sidewall[i];
     if (fabs(fabs(actual)-fabs(expected)) > tolerance * fmax(fabs(actual), fabs(expected))) {
@@ -1052,7 +1053,7 @@ int test_helper_functions_on_octagonal_c_prism() {
   intersect_line_with_prism_b_tapered_sidewall[8] = 300; // between top point 3 and center of c on bottom
 
   double intersect_line_with_prism_actual_tapered_sidewall[intersect_line_with_prism_test_points_tapered_sidewall.num_items];
-  for (int i = 0; i < intersect_line_with_prism_test_points_tapered_sidewall.num_items; i++) {
+  for (i = 0; i < intersect_line_with_prism_test_points_tapered_sidewall.num_items; i++) {
     num_tests_tapered++;
     vector3 p = intersect_line_with_prism_test_points_tapered_sidewall.items[i];
     vector3 d = intersect_line_with_prism_test_vectors_tapered_sidewall[i];
@@ -1062,7 +1063,7 @@ int test_helper_functions_on_octagonal_c_prism() {
     intersect_line_with_prism_actual_tapered_sidewall[i] = intersect_line_segment_with_object(p, d, o, a, b);
   }
 
-  for (int i = 0; i < intersect_line_with_prism_test_points_tapered_sidewall.num_items; i++) {
+  for (i = 0; i < intersect_line_with_prism_test_points_tapered_sidewall.num_items; i++) {
     double actual = intersect_line_with_prism_actual_tapered_sidewall[i];
     double expected = intersect_line_with_prism_expected_tapered_sidewall[i];
     if (fabs(fabs(actual)-fabs(expected)) > tolerance * fmax(fabs(actual), fabs(expected))) {


### PR DESCRIPTION
Attempt to address https://github.com/NanoComp/libctl/pull/53#issuecomment-585901891 and get CI back for MPB.

There are *a lot* of variable declarations in `utils/test-prism.c` that are not at the beginning of blocks; I think that is nominally not C89/90 compliant, but if I [understand correctly](https://stackoverflow.com/a/288455/9911781) it should not be a problem under gcc. 
Thus, I just restricted myself to fixing the declarations inside loop blocks.

I also added an exclusion of .dat files to `.gitignore`, which are generated when running the libctl checks now.