### PR TITLE
Correctly deallocate memory in `destroy_geom_box_tree`

### DIFF
--- a/utils/geom.c
+++ b/utils/geom.c
@@ -1359,7 +1359,7 @@ void destroy_geom_box_tree(geom_box_tree t) {
   if (t) {
     destroy_geom_box_tree(t->t1);
     destroy_geom_box_tree(t->t2);
-    if (t->nobjects && t->objects) FREE(t->objects);
+    if (t->objects) FREE(t->objects);
     FREE1(t);
   }
 }


### PR DESCRIPTION
If `nobjects` is zero, then MALLOC is still called during the construction of the tree. However, `malloc` implementations can choose to return a non-NULL pointer in that case and the returned pointer should be freed in order to prevent leaks: https://en.cppreference.com/w/c/memory/malloc