### PR TITLE
Center calculation of the prism when height is defined though python as inifinity

### DIFF
--- a/utils/geom.c
+++ b/utils/geom.c
@@ -2629,10 +2629,17 @@ void init_prism(geometric_object *o) {
   }
 
   // set current_center=prism center as determined by vertices and height.
+  // If height of the prism defined as infinity in python interface do not
+  // use it to calculate the center.
   // if the center of the geometric object was left unspecified,
   // set it to current_center; otherwise displace the entire prism
   // so that it is centered at the specified center.
-  vector3 current_center = vector3_plus(centroid, vector3_scale(0.5 * prsm->height, prsm->axis));
+  vector3 current_center;
+  // 1e20 <- value of infinity in python interface
+  if(prsm->height >= 1e20)
+    current_center = centroid;
+  else
+     current_center = vector3_plus(centroid, vector3_scale(0.5 * prsm->height, prsm->axis));
   if (isnan(o->center.x) && isnan(o->center.y) && isnan(o->center.z)) // center == auto-center
     o->center = current_center;
   else {

--- a/utils/geom.c
+++ b/utils/geom.c
@@ -2639,7 +2639,7 @@ void init_prism(geometric_object *o) {
   if(prsm->height >= 1e20)
     current_center = centroid;
   else
-     current_center = vector3_plus(centroid, vector3_scale(0.5 * prsm->height, prsm->axis));
+    current_center = vector3_plus(centroid, vector3_scale(0.5 * prsm->height, prsm->axis));
   if (isnan(o->center.x) && isnan(o->center.y) && isnan(o->center.z)) // center == auto-center
     o->center = current_center;
   else {


### PR DESCRIPTION
Initial issue: https://github.com/NanoComp/meep/issues/2144
Previously, half of the height of the prism along prism axis was added to the center in python interface during prism initilization, this caused incorrect behaviour when custom center of the prism was specified in 2d case, this PR fixes it : https://github.com/NanoComp/meep/pull/2188 while it alone should resolve the issue, another inconsistency arise from the fact that libctl also checking center of the prism and then shifts the vertices if calculated center of the prism does not coincide with defined center of the prism.