### PR TITLE
fix memory leak in geom_fix_object_list via init_prism

### DIFF
--- a/utils/geom.c
+++ b/utils/geom.c
@@ -81,6 +81,7 @@ static double get_prism_volume(prism *prsm);
 static void get_prism_bounding_box(prism *prsm, geom_box *box);
 static void display_prism_info(int indentby, geometric_object *o);
 static void init_prism(geometric_object *o);
+static void reinit_prism(geometric_object *o);
 /**************************************************************************/
 
 /* Allows writing to Python's stdout when running from Meep's Python interface */
@@ -157,7 +158,7 @@ void geom_fix_object_ptr(geometric_object *o) {
       break;
     }
     case GEOM PRISM: {
-      init_prism(o);
+      reinit_prism(o);
       break;
     }
     case GEOM COMPOUND_GEOMETRIC_OBJECT: {
@@ -2797,6 +2798,8 @@ void init_prism(geometric_object *o) {
       prsm->vertices_top_p.items[nv].x = px;
       prsm->vertices_top_p.items[nv].y = py;
     }
+
+    free(top_polygon_edges);
   }
 
   prsm->top_polygon_diff_vectors_p.num_items = num_vertices;
@@ -2824,6 +2827,19 @@ void init_prism(geometric_object *o) {
   // that is used by some geometry routines
   prsm->workspace.num_items = num_vertices + 2;
   prsm->workspace.items = (double *)malloc((num_vertices + 2) * sizeof(double));
+}
+
+/* like init_prism, but works with an already-initialied prism */
+void reinit_prism(geometric_object *o) {
+  // these arrays are re-allocated by init_prism
+  free(prsm->vertices_p.items);
+  free(prsm->vertices_top_p.items);
+  free(prsm->top_polygon_diff_vectors_p.items);
+  free(prsm->top_polygon_diff_vectors_scaled_p.items);
+  free(prsm->vertices_top.items);
+  free(prsm->workspace.items);
+
+  init_prism(o);
 }
 
 /***************************************************************/

--- a/utils/geom.c
+++ b/utils/geom.c
@@ -2832,6 +2832,7 @@ void init_prism(geometric_object *o) {
 /* like init_prism, but works with an already-initialied prism */
 void reinit_prism(geometric_object *o) {
   // these arrays are re-allocated by init_prism
+  prism *prsm = o->subclass.prism_data;
   free(prsm->vertices_p.items);
   free(prsm->vertices_top_p.items);
   free(prsm->top_polygon_diff_vectors_p.items);

--- a/utils/test-prism.c
+++ b/utils/test-prism.c
@@ -480,6 +480,7 @@ int test_square_base_sidewall_prisms_to_gnuplot() {
 
   double normal_sidewall = 0;
   geometric_object square_normal_sidewall_geom_object = make_prism(m, nodes_square, num_nodes_square, height_square, zhat);
+  geom_fix_object_ptr(&square_normal_sidewall_geom_object);
   prism *square_normal_sidewall_prism = square_normal_sidewall_geom_object.subclass.prism_data;
 
   double one_degree_sidewall = 1.0 * 2 * K_PI / 360.0;
@@ -524,6 +525,7 @@ int test_octagon_c_base_sidewall_prisms_to_gnuplot() {
 
   double normal_sidewall = 0;
   geometric_object octagon_c_normal_sidewall_geom_object = make_prism(m, nodes_octagon_c, num_nodes_octagon_c, height_octagon_c, zhat);
+  geom_fix_object_ptr(&octagon_c_normal_sidewall_geom_object);
   prism *octagon_c_normal_sidewall_prism = octagon_c_normal_sidewall_geom_object.subclass.prism_data;
 
   double two_half_degree_sidewall = 2.5 * 2 * K_PI / 360.0;
@@ -575,6 +577,7 @@ int test_helper_functions_on_octagonal_c_prism() {
 
   double normal_sidewall = 0;
   geometric_object octagon_c_normal_sidewall_geom_object = make_prism(m, nodes_octagon_c, num_nodes_octagon_c, height_octagon_c, zhat);
+  geom_fix_object_ptr(&octagon_c_normal_sidewall_geom_object);
   prism *octagon_c_normal_sidewall_prism = octagon_c_normal_sidewall_geom_object.subclass.prism_data;
 
   double two_half_degree_sidewall = 2.5 * 2 * K_PI / 360.0;
@@ -1121,6 +1124,8 @@ int run_unit_tests() {
 
   geometric_object the_block = make_block(m, c, xhat, yhat, zhat, size);
   geometric_object the_prism = make_prism(m, v, 4, LZ, zhat);
+  geom_fix_object_ptr(&the_block);
+  geom_fix_object_ptr(&the_prism);
 
   /***************************************************************/
   /* with probability P_SHIFT, shift the centers of both block   */
@@ -1265,6 +1270,7 @@ int main(int argc, char *argv[]) {
   fclose(f);
 
   geometric_object the_prism = make_prism(NULL, vertices, num_vertices, height, axis);
+  geom_fix_object_ptr(&the_prism);
   prism *prsm = the_prism.subclass.prism_data;
   prism2gmsh(prsm, "test-prism.pp");
   prism2gnuplot(prsm, "test-prism.gp");


### PR DESCRIPTION
Fixes memory leak reported in https://github.com/NanoComp/meep/issues/3192, and other leak that occurs in prisms with sidewall angles.

cc @Luochenghuang