### PR TITLE
Fix init_prism centroid; make test-prism's parallel loops thread-safe

### DIFF
--- a/utils/geom.c
+++ b/utils/geom.c
@@ -250,7 +250,6 @@ void geom_initialize(void) {
    has been called on o (if the lattice basis is non-orthogonal).  */
 
 boolean CTLIO point_in_objectp(vector3 p, geometric_object o) {
-  geom_fix_object_ptr(&o);
   return point_in_fixed_objectp(p, o);
 }
 
@@ -398,7 +397,6 @@ vector3 from_geom_object_coords(vector3 p, geometric_object o) {
    sign of the normal vector are arbitrary. */
 
 vector3 CTLIO normal_to_object(vector3 p, geometric_object o) {
-  geom_fix_object_ptr(&o);
   return normal_to_fixed_object(p, o);
 }
 
@@ -526,7 +524,6 @@ vector3 normal_to_fixed_object(vector3 p, geometric_object o) {
    by the lattice vectors: */
 
 boolean CTLIO point_in_periodic_objectp(vector3 p, geometric_object o) {
-  geom_fix_object_ptr(&o);
   return point_in_periodic_fixed_objectp(p, o);
 }
 
@@ -2600,12 +2597,14 @@ void init_prism(geometric_object *o) {
     vertices = (vector3 *)realloc(vertices, num_vertices * sizeof(vector3));
   }
 
-  // compute centroid of vertices
+  // compute centroid of vertices; prsm->centroid is assigned below, AFTER
+  // the optional shift to o->center is applied (otherwise prsm->centroid
+  // would be stale relative to the shifted vertices).
   vector3 centroid = {0.0, 0.0, 0.0};
   int nv;
   for (nv = 0; nv < num_vertices; nv++)
     centroid = vector3_plus(centroid, vertices[nv]);
-  prsm->centroid = centroid = vector3_scale(1.0 / ((double)num_vertices), centroid);
+  centroid = vector3_scale(1.0 / ((double)num_vertices), centroid);
 
   // make sure all vertices lie in a plane, i.e. that the normal
   // vectors to all triangles (v_n, v_{n+1}, centroid) agree.
@@ -2656,6 +2655,7 @@ void init_prism(geometric_object *o) {
       vertices[nv] = vector3_plus(vertices[nv], shift);
     centroid = vector3_plus(centroid, shift);
   }
+  prsm->centroid = centroid;
 
   // compute rotation matrix that operates on a vector of cartesian coordinates
   // to yield the coordinates of the same point in the prism coordinate system.

--- a/utils/geom.c
+++ b/utils/geom.c
@@ -247,9 +247,16 @@ void geom_initialize(void) {
    initialized.
 
    point_in_fixed_objectp additionally requires that geom_fix_object
-   has been called on o (if the lattice basis is non-orthogonal).  */
+   has been called on o (if the lattice basis is non-orthogonal).
+
+   NOT THREAD-SAFE: calls geom_fix_object_ptr, which mutates per-object
+   cached state (and for prisms, frees+reallocates shared arrays).
+   Callers that query the same object from multiple threads must
+   geom_fix_object_ptr once up-front and then call
+   point_in_fixed_objectp / point_in_fixed_pobjectp directly. */
 
 boolean CTLIO point_in_objectp(vector3 p, geometric_object o) {
+  geom_fix_object_ptr(&o);
   return point_in_fixed_objectp(p, o);
 }
 
@@ -394,9 +401,16 @@ vector3 from_geom_object_coords(vector3 p, geometric_object o) {
    in lattice coordinates, using the surface of the object that the
    point is "closest" to for some definition of "closest" that is
    reasonable (at least for points near to the object). The length and
-   sign of the normal vector are arbitrary. */
+   sign of the normal vector are arbitrary.
+
+   NOT THREAD-SAFE: calls geom_fix_object_ptr, which mutates per-object
+   cached state (and for prisms, frees+reallocates shared arrays).
+   Callers that query the same object from multiple threads must
+   geom_fix_object_ptr once up-front and then call
+   normal_to_fixed_object directly. */
 
 vector3 CTLIO normal_to_object(vector3 p, geometric_object o) {
+  geom_fix_object_ptr(&o);
   return normal_to_fixed_object(p, o);
 }
 
@@ -521,9 +535,16 @@ vector3 normal_to_fixed_object(vector3 p, geometric_object o) {
 /**************************************************************************/
 
 /* Like point_in_objectp, but also checks the object shifted
-   by the lattice vectors: */
+   by the lattice vectors.
+
+   NOT THREAD-SAFE: calls geom_fix_object_ptr, which mutates per-object
+   cached state (and for prisms, frees+reallocates shared arrays).
+   Callers that query the same object from multiple threads must
+   geom_fix_object_ptr once up-front and then call
+   point_in_periodic_fixed_objectp directly. */
 
 boolean CTLIO point_in_periodic_objectp(vector3 p, geometric_object o) {
+  geom_fix_object_ptr(&o);
   return point_in_periodic_fixed_objectp(p, o);
 }
 

--- a/utils/test-prism.c
+++ b/utils/test-prism.c
@@ -280,11 +280,15 @@ int test_point_inclusion(geometric_object the_block, geometric_object the_prism,
   int num_failed = 0, num_adjusted = 0, n;
   char *exclude_env = getenv("LIBCTL_EXCLUDE_BOUNDARIES");
   boolean libctl_include_boundaries = !(exclude_env && exclude_env[0] == '1');
+  // Use point_in_fixed_objectp instead of point_in_objectp because the
+  // latter calls geom_fix_object_ptr internally and is not thread-safe.
+  // the_block and the_prism were fixed up in run_unit_tests above
+  // before this parallel loop runs.
 #pragma omp parallel for schedule(dynamic) reduction(+ : num_failed, num_adjusted)
   for (n = 0; n < num_tests; n++) {
     vector3 p = random_point_in_box(min_corner, max_corner);
-    boolean in_block = point_in_objectp(p, the_block);
-    boolean in_prism = point_in_objectp(p, the_prism);
+    boolean in_block = point_in_fixed_objectp(p, the_block);
+    boolean in_prism = point_in_fixed_objectp(p, the_prism);
 
     if (in_block != in_prism) {
       // retry with boundary exclusion/inclusion reversed
@@ -330,8 +334,10 @@ int test_normal_to_object(geometric_object the_block, geometric_object the_prism
     vector3 p = (urand(0.0, 1.0) < PFACE) ? random_point_on_prism(the_prism)
                                           : random_point_in_box(min_corner, max_corner);
 
-    vector3 nhat_block = standardize(normal_to_object(p, the_block));
-    vector3 nhat_prism = standardize(normal_to_object(p, the_prism));
+    // normal_to_fixed_object instead of normal_to_object: the latter is
+    // not thread-safe (calls geom_fix_object_ptr internally).
+    vector3 nhat_block = standardize(normal_to_fixed_object(p, the_block));
+    vector3 nhat_prism = standardize(normal_to_fixed_object(p, the_prism));
     if (!vector3_nearly_equal(nhat_block, nhat_prism, tolerance)) num_failed++;
 
     if (f) {

--- a/utils/test-prism.c
+++ b/utils/test-prism.c
@@ -1150,6 +1150,11 @@ int run_unit_tests() {
     vector3 shift = vector3_scale(urand(0.0, 1.0), random_unit_vector3());
     the_block.center = vector3_plus(the_block.center, shift);
     the_prism.center = vector3_plus(the_prism.center, shift);
+    // Sync each object's internal cache (block projection_matrix, prism
+    // vertices_p / centroid) to the new center, once, single-threaded,
+    // before the parallel test loops below run.
+    geom_fix_object_ptr(&the_block);
+    geom_fix_object_ptr(&the_prism);
   }
 
   char *s = getenv("LIBCTL_TEST_PRISM_LOG");


### PR DESCRIPTION
After #75 + #79, `test-prism` with `--enable-openmp` was still failing at `OMP_NUM_THREADS >= 2` with heap corruption and intermittent point-inclusion mismatches. Two issues.

## 1. `init_prism` writes `prsm->centroid` before the optional shift

The line `prsm->centroid = centroid = ...` happens before the `else` block that shifts both `vertices` and the local `centroid` to land on `o->center`. The shift only updates the local — `prsm->centroid` stays at the pre-shift value, while the vertex arrays reflect the shifted geometry. Block-vs-prism point-inclusion then disagrees on the difference between old and new placement.

The pre-PR auto-fix in `point_in_objectp` masked this in serial code (the second call recomputed `centroid` from the now-shifted vertices), but #79's parallel loop exposed it.

Fix: move `prsm->centroid = centroid;` to after the if/else. Idempotent in serial code too — not OpenMP-specific.

## 2. test-prism's parallel loops were calling the thread-unsafe wrappers

`point_in_objectp` / `normal_to_object` / `point_in_periodic_objectp` call `geom_fix_object_ptr` on every invocation, which for prisms does `free`/`malloc` on shared per-prism arrays. Two threads racing on the same prism corrupt the allocator — the original crash from #79.

The wrappers are kept as-is (preserving API contract for callers that mutate object parameters between queries) but their doc comments now mark them as not thread-safe and direct concurrent callers at the `*_fixed_*` variants.

In test-prism:
- `test_point_inclusion`: switch to `point_in_fixed_objectp`.
- `test_normal_to_object` (disabled but still parallel): switch to `normal_to_fixed_object`.
- `run_unit_tests`: call `geom_fix_object_ptr` on `the_block` and `the_prism` inside the `P_SHIFT` block, before the parallel loops run.

## Verification

`make check` passes. Three trials each at `OMP_NUM_THREADS = 1, 2, 4, 8, 16, 64, 166`: 21/21 clean (0/10000 points failed, 0/1000 segments failed, no heap-corruption signatures).
