### PR TITLE
Prepare for 4.7.0 release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 * Bug fixes for thread safety (#75, #81).
 
-* Support for multithreading via configure flag `--enable-openmp` (#79).
+* Enable thread-safety tests via configure flag `--enable-openmp` (#79); the library itself is still single-threaded (but many functions of libctlgeom are thread-safe).
 
 * CI workflow via Github Actions (#85).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # Libctl Release Notes
 
+## libctl 4.7.0
+
+5/12/2026
+
+* New mesh geometry object (#74).
+
+* Bug fixes for thread safety (#75, #81).
+
+* Support for multithreading via configure flag `--enable-openmp` (#79).
+
+* CI workflow via Github Actions (#85).
+
 ## libctl 4.6.0
 
 4/16/2026

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## libctl 4.7.0
 
-5/12/2026
+6/18/2026
 
 * New mesh geometry object (#74).
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 # Process this file with autoconf to produce a configure script.
-AC_INIT([libctl],[4.6.0],[stevenj@alum.mit.edu])
+AC_INIT([libctl],[4.7.0],[stevenj@alum.mit.edu])
 AC_CONFIG_SRCDIR([src/ctl.c])
 AC_CONFIG_HEADERS([config.h src/ctl.h])
 AC_CONFIG_MACRO_DIR([m4])
@@ -8,7 +8,7 @@ AM_MAINTAINER_MODE
 # Shared-library version number; indicates api compatibility, and is
 # not the same as the "public" version number.  (Don't worry about this
 # except for public releases.)
-SHARED_VERSION_INFO="10:2:3" # CURRENT:REVISION:AGE
+SHARED_VERSION_INFO="10:2:4" # CURRENT:REVISION:AGE
 
 AM_INIT_AUTOMAKE([foreign])
 AC_SUBST(SHARED_VERSION_INFO)

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ AM_MAINTAINER_MODE
 # Shared-library version number; indicates api compatibility, and is
 # not the same as the "public" version number.  (Don't worry about this
 # except for public releases.)
-SHARED_VERSION_INFO="10:2:4" # CURRENT:REVISION:AGE
+SHARED_VERSION_INFO="11:0:4" # CURRENT:REVISION:AGE
 
 AM_INIT_AUTOMAKE([foreign])
 AC_SUBST(SHARED_VERSION_INFO)


### PR DESCRIPTION
The next tarball release is tenatively scheduled for Friday June 12, 2026.