### PR TITLE
Use combined rel+abs tolerance for line-segment test in `test-prism`

### DIFF
--- a/utils/test-prism.c
+++ b/utils/test-prism.c
@@ -375,12 +375,8 @@ int test_line_segment_intersection(geometric_object the_block, geometric_object 
 
     double sblock = intersect_line_segment_with_object(p, d, the_block, a, b);
     double sprism = intersect_line_segment_with_object(p, d, the_prism, a, b);
-    // Relative tolerance plus a floor proportional to the object's size, rather
-    // than a hard-coded length, so a segment that merely grazes the shared
-    // boundary (both intersection lengths ~0) isn't flagged as a spurious fail.
     double diff = fabs(sblock - sprism);
-    double scale = fmax(fabs(sblock), fabs(sprism));
-    double tol = 1.0e-6 * scale + 1.0e-5 * vector3_norm(size);
+    double tol = 1.0e-5 * vector3_norm(size);
     if (diff > tol) num_failed++;
 
     if (f) {

--- a/utils/test-prism.c
+++ b/utils/test-prism.c
@@ -375,10 +375,16 @@ int test_line_segment_intersection(geometric_object the_block, geometric_object 
 
     double sblock = intersect_line_segment_with_object(p, d, the_block, a, b);
     double sprism = intersect_line_segment_with_object(p, d, the_prism, a, b);
-    if (fabs(sblock - sprism) > 1.0e-6 * fmax(fabs(sblock), fabs(sprism))) num_failed++;
+    // Relative tolerance plus a floor proportional to the object's size, rather
+    // than a hard-coded length, so a segment that merely grazes the shared
+    // boundary (both intersection lengths ~0) isn't flagged as a spurious fail.
+    double diff = fabs(sblock - sprism);
+    double scale = fmax(fabs(sblock), fabs(sprism));
+    double tol = 1.0e-6 * scale + 1.0e-5 * vector3_norm(size);
+    if (diff > tol) num_failed++;
 
     if (f) {
-      int success = fabs(sblock - sprism) <= 1.0e-6 * fmax(fabs(sblock), fabs(sprism));
+      int success = diff <= tol;
 #pragma omp critical(test_prism_log)
       {
         fprintf(f, " %e %e %s\n", sblock, sprism, success ? "success" : "fail");


### PR DESCRIPTION
The line-segment unit test compared a prism against an equivalent block using a pure relative tolerance. When a random segment merely grazes the shared boundary, both intersection lengths are tiny and the relative test becomes hypersensitive to the prism's internal boundary tolerance (~1e-5), producing intermittent CI failures. Add an absolute floor so boundary- ambiguous samples are absorbed while genuine divergence is still caught.