### PR TITLE
fix distclean, add distcheck to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           sh autogen.sh --prefix=$PWD/.local --enable-openmp
           make
-          make check
+          make distcheck
           make install
 
       - name: Print test logs on failure

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -36,6 +36,8 @@ dist_man_MANS = gen-ctl-io.1
 
 BUILT_SOURCES = gen-ctl-io geom-ctl-io.c ctlgeom-types.h nlopt-constants.scm
 
+DISTCLEANFILES = octagon_c_normal_sidewall_gnu_plot.dat octagon_c_two_half_degree_sidewall_gnu_plot.dat square_normal_sidewall_gnu_plot.dat square_one_degree_sidewall_gnu_plot.dat
+
 nlopt-constants.scm:
 	echo "#include <nlopt.h>" > nlopt-constants.h
 	echo "; AUTOMATICALLY GENERATED - DO NOT EDIT" > $@


### PR DESCRIPTION
Fixes `make distclean` by removing `.dat` files that are generated by the tests, and add `make distcheck` (instead of `make check`) to CI.